### PR TITLE
Update for Cardinal specific behaviour

### DIFF
--- a/src/BusDepot.cpp
+++ b/src/BusDepot.cpp
@@ -652,8 +652,8 @@ struct BusDepotWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/BusRoute.cpp
+++ b/src/BusRoute.cpp
@@ -473,8 +473,8 @@ struct BusRouteWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/EnterBus.cpp
+++ b/src/EnterBus.cpp
@@ -195,8 +195,8 @@ struct EnterBusWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/ExitBus.cpp
+++ b/src/ExitBus.cpp
@@ -185,8 +185,8 @@ struct ExitBusWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/GigBus.cpp
+++ b/src/GigBus.cpp
@@ -587,8 +587,8 @@ struct GigBusWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/MetroCityBus.cpp
+++ b/src/MetroCityBus.cpp
@@ -785,8 +785,8 @@ struct MetroCityBusWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/MiniBus.cpp
+++ b/src/MiniBus.cpp
@@ -516,8 +516,8 @@ struct MiniBusWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/Road.cpp
+++ b/src/Road.cpp
@@ -386,8 +386,8 @@ struct RoadWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();

--- a/src/SchoolBus.cpp
+++ b/src/SchoolBus.cpp
@@ -660,8 +660,8 @@ struct SchoolBusWidget : ModuleWidget {
 	void step() override {
 #ifdef USING_CARDINAL_NOT_RACK
 		Widget* panel = getPanel();
-		panel->visible = !settings::darkMode;
-		night_panel->visible = settings::darkMode;
+		panel->visible = !settings::preferDarkPanels;
+		night_panel->visible = settings::preferDarkPanels;
 #else
 		if (module) {
 			Widget* panel = getPanel();


### PR DESCRIPTION
Cardinal has changed to stop using its custom `settings::darkMode` property, with now using `settings::preferDarkPanels` from VCV Rack.